### PR TITLE
Add new support for Vulkan Driver to Wuthering Waves Android

### DIFF
--- a/Android/Vulkan Experimental/DeviceProfiles.ini
+++ b/Android/Vulkan Experimental/DeviceProfiles.ini
@@ -1,0 +1,4 @@
+[Android DeviceProfile]
+CVars=r.Android.DisableVulkanSM5Support=0
+CVars=r.Android.DisableVulkanSupport=0
+CVars=r.Vulkan.DescriptorSetLayoutMode=0


### PR DESCRIPTION
This change will make Wuthering Waves run on newly supported Vulkan Driver. Even though it's still buggy and glitchy, but the performance boost in the other hand are very good.

Here's the video sample of one of my friend using Vulkan Driver.

https://github.com/user-attachments/assets/90788d40-6ca8-4b23-9663-dc588a4ec164

As you can see, it's still buggy. But i'm just gonna PR this real quick because why not.